### PR TITLE
github.com/kr/pretty.go was renamed to github.com/kr/pretty

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -2,7 +2,7 @@ package assert
 // Testing helpers for doozer.
 
 import (
-	"github.com/kr/pretty.go"
+	"github.com/kr/pretty"
 	"reflect"
 	"testing"
 	"runtime"


### PR DESCRIPTION
github.com/kr/pretty.go was renamed to github.com/kr/pretty
this just addresses that name change in the imports 
